### PR TITLE
Filename width fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 install:
   - go get github.com/ActiveState/tail
   - go get github.com/mattn/go-colorable
+  - go get github.com/mattn/go-runewidth
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.5
 
 install:
-  - go get github.com/ActiveState/tail
+  - go get github.com/hpcloud/tail
   - go get github.com/mattn/go-colorable
   - go get github.com/mattn/go-runewidth
   - go get github.com/axw/gocov/gocov

--- a/tailer.go
+++ b/tailer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hpcloud/tail"
 	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-runewidth"
 )
 
 var (
@@ -83,8 +84,9 @@ func maximumNameLength(filenames []string) int {
 	max := 0
 	for _, name := range filenames {
 		base := filepath.Base(name)
-		if len(base) > max {
-			max = len(base)
+		width := runewidth.StringWidth(base)
+		if width > max {
+			max = width
 		}
 	}
 	return max

--- a/tailer_test.go
+++ b/tailer_test.go
@@ -96,7 +96,7 @@ func TestMaximumNameLength(t *testing.T) {
 	}{
 		{"a", 1},
 		{"ab", 2},
-		{"世界一かわいいよ", 8},
+		{"世界一かわいいよ", 16},
 		{"/p/t/very_very_long_base", 19}}
 	names := make([]string, 4)
 	for _, n := range ns {

--- a/tailer_test.go
+++ b/tailer_test.go
@@ -30,10 +30,6 @@ func TestNewTailers(t *testing.T) {
 		t.Fatalf("Incorrect: tailers count expect(%d) actual(%d)", len(names), len(tailers))
 	}
 
-	if tailers[0].maxWidth != 19 { // len("very_very_long_base")
-		t.Fatalf("Incorrect: maximum name length: expect(%d) actual(%d)", 19, tailers[0].maxWidth)
-	}
-
 	if tailers[0].colorCode != ansiColorCodes[0] {
 		t.Fatal("Incorrect color code at 1st file")
 	}
@@ -96,6 +92,7 @@ func TestMaximumNameLength(t *testing.T) {
 	}{
 		{"a", 1},
 		{"ab", 2},
+		{"/very/very/long/path/but/base/is/short", 5},
 		{"世界一かわいいよ", 16},
 		{"/p/t/very_very_long_base", 19}}
 	names := make([]string, 4)

--- a/tailer_test.go
+++ b/tailer_test.go
@@ -88,3 +88,22 @@ func TestTailerDo(t *testing.T) {
 func revertDefault() {
 	colorableOutput = defaultOutput
 }
+
+func TestMaximumNameLength(t *testing.T) {
+	ns := []struct {
+		name   string
+		length int
+	}{
+		{"a", 1},
+		{"ab", 2},
+		{"世界一かわいいよ", 8},
+		{"/p/t/very_very_long_base", 19}}
+	names := make([]string, 4)
+	for _, n := range ns {
+		names = append(names, n.name)
+		cl := maximumNameLength(names)
+		if n.length != cl {
+			t.Fatalf("Incorrect: Maximum name length: expect(%d) actual(%d)", n.length, cl)
+		}
+	}
+}


### PR DESCRIPTION
Some people have unicode filenames. They obviously misalign with naive width calculations.