### PR TITLE
Stop all tailers in need.

### DIFF
--- a/ninetail.go
+++ b/ninetail.go
@@ -49,3 +49,17 @@ func (n *NineTail) Run() {
 
 	wg.Wait()
 }
+
+func (n *NineTail) Stop() {
+	var wg sync.WaitGroup
+
+	for _, t := range n.tailers {
+		wg.Add(1)
+		go func(t *Tailer) {
+			t.Stop()
+			wg.Done()
+		}(t)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Run all tailers in a routine, and stop in another when receive SIGINT, 
so main routing can keep running.