### PR TITLE
Update CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 go:
   - 1.11.x
 
+branches:
+  only:
+    - master
+
 install:
   - go get github.com/hpcloud/tail
   - go get github.com/mattn/go-colorable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: go
 go:
-  - 1.5
+  - 1.11.x
 
 install:
   - go get github.com/hpcloud/tail
   - go get github.com/mattn/go-colorable
   - go get github.com/mattn/go-runewidth
-  - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - $GOPATH/bin/goveralls -service=travis-ci


### PR DESCRIPTION
- go version to 1.11
- unnecessary gotools cover install